### PR TITLE
feat: Implement base types & Uplink 'access'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ keywords = ["storj", "storjlabs", "decentralized", "binding", "uplink"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+uplink-sys = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -17,3 +17,26 @@ UNSAFE everywhere.
 
 This crate offers an idiomatic and safe (you don't have to use the __unsafe__
 keyword for using it) Rust crate library based on the Bindgen former.
+
+## Implementation progress
+
+Entities:
+
+- [X] [Access](https://pkg.go.dev/storj.io/uplink#Access)
+  - [X] [Permission](https://pkg.go.dev/storj.io/uplink#Permission)
+  - [X] [Share Prefix](https://pkg.go.dev/storj.io/uplink#SharePrefix)
+- [ ] [Bucket](https://pkg.go.dev/storj.io/uplink#Bucket)
+- [ ] [Bucket Iterator](https://pkg.go.dev/storj.io/uplink#BucketIterator)
+- [ ] [Config](https://pkg.go.dev/storj.io/uplink#Config)
+- [ ] [Custom Metadata](https://pkg.go.dev/storj.io/uplink#CustomMetadata)
+- [ ] [Download](https://pkg.go.dev/storj.io/uplink#Download)
+- [ ] [Download Options](https://pkg.go.dev/storj.io/uplink#DownloadOptions)
+- [ ] [Encryption Key](https://pkg.go.dev/storj.io/uplink#EncryptionKey)
+- [ ] [List Buckets Options](https://pkg.go.dev/storj.io/uplink#ListBucketsOptions)
+- [ ] [List Objects Options](https://pkg.go.dev/storj.io/uplink#ListObjectsOptions)
+- [ ] [Object](https://pkg.go.dev/storj.io/uplink#Object)
+- [ ] [Object Iterator](https://pkg.go.dev/storj.io/uplink#ObjectIterator)
+- [ ] [Project](https://pkg.go.dev/storj.io/uplink#Project)
+- [ ] [System Metadata](https://pkg.go.dev/storj.io/uplink#SystemMetadata)
+- [ ] [Upload](https://pkg.go.dev/storj.io/uplink#Upload)
+- [ ] [Upload Options](https://pkg.go.dev/storj.io/uplink#UploadOptions)

--- a/src/access.rs
+++ b/src/access.rs
@@ -1,0 +1,652 @@
+//! Storj DCS Access Grant.
+
+use crate::helpers;
+use crate::EncryptionKey;
+use crate::Ensurer;
+use crate::Error;
+
+use std::ffi::{CStr, CString};
+use std::time::Duration;
+use std::vec::Vec;
+
+use uplink_sys as ulksys;
+
+/// Represents an Access Grant
+///
+/// An Access Grant contains everything to access a project and specific
+/// buckets.
+///
+/// It includes a potentially-restricted API Key, a potentially-restricted set
+/// of encryption information, and information about the Satellite responsible
+/// for the project's metadata.
+pub struct Access {
+    inner: ulksys::UplinkAccessResult,
+}
+
+impl Access {
+    /// Creates a new Access from a serialized access grant string.
+    pub fn new(saccess: &str) -> Result<Self, Error> {
+        let saccess = match helpers::cstring_from_str_fn_arg("saccess", saccess) {
+            Ok(cs) => cs,
+            Err(e) => return Err(e),
+        };
+
+        let accres;
+        // SAFETY: we trust that the underlying c-binding is safe, nonetheless
+        // we ensure accres is correct through the ensure method of the
+        // implemented Ensurer trait.
+        unsafe {
+            accres = *ulksys::uplink_parse_access(saccess.into_raw()).ensure();
+        }
+
+        if let Some(e) = Error::new_uplink(accres.error) {
+            return Err(e);
+        }
+
+        Ok(Access { inner: accres })
+    }
+
+    /// generates a new access grant using a passphrase requesting to the
+    /// Satellite a project-based salt for deterministic key derivation.
+    pub fn request_access_with_passphrase(
+        satellite_addr: &str,
+        api_key: &str,
+        passphrase: &str,
+    ) -> Result<Self, Error> {
+        let satellite_addr =
+            match helpers::cstring_from_str_fn_arg("sattellite_addr", satellite_addr) {
+                Ok(cs) => cs,
+                Err(e) => return Err(e),
+            };
+        let api_key = match helpers::cstring_from_str_fn_arg("api_key", api_key) {
+            Ok(cs) => cs,
+            Err(e) => return Err(e),
+        };
+        let passphrase = match helpers::cstring_from_str_fn_arg("passphrase", passphrase) {
+            Ok(cs) => cs,
+            Err(e) => return Err(e),
+        };
+
+        let accres;
+        // SAFETY: we trust that the underlying c-binding is safe, nonetheless
+        // we ensure accres is correct through the ensure method of the
+        // implemented Ensurer trait.
+        unsafe {
+            accres = *ulksys::uplink_request_access_with_passphrase(
+                satellite_addr.into_raw(),
+                api_key.into_raw(),
+                passphrase.into_raw(),
+            )
+            .ensure();
+        }
+
+        if let Some(e) = Error::new_uplink(accres.error) {
+            return Err(e);
+        }
+
+        Ok(Access { inner: accres })
+    }
+
+    /// overrides the root encryption key for the prefix in bucket with the
+    /// encryption key.
+    /// This method is useful for overriding the encryption key in user-specific
+    /// access grants when implementing multitenancy in a single app bucket.
+    /// See relevant information in the general crate documentation.
+    pub fn override_encryption_key(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        encryption_key: &EncryptionKey,
+    ) -> Result<(), Error> {
+        let bucket = match helpers::cstring_from_str_fn_arg("bucket", bucket) {
+            Ok(cs) => cs,
+            Err(e) => return Err(e),
+        };
+
+        let prefix = match helpers::cstring_from_str_fn_arg("prefix", prefix) {
+            Ok(cs) => cs,
+            Err(e) => return Err(e),
+        };
+
+        let err;
+        // SAFETY: we trust that the underlying c-binding is safe.
+        unsafe {
+            err = ulksys::uplink_access_override_encryption_key(
+                self.inner.access,
+                bucket.into_raw(),
+                prefix.into_raw(),
+                encryption_key.into_raw_mut(),
+            );
+        }
+
+        match Error::new_uplink(err) {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// It returns the satellite node URL associated with this access grant.
+    pub fn satellite_address(&self) -> Result<&str, Error> {
+        let strres;
+        // SAFETY: we trust that the underlying c-binding is safe, nonetheless
+        // we ensure strres is correct through the ensure method of the
+        // implemented Ensurer trait.
+        unsafe {
+            strres = *ulksys::uplink_access_satellite_address(self.inner.access).ensure();
+        }
+
+        if let Some(e) = Error::new_uplink(strres.error) {
+            return Err(e);
+        }
+
+        let addrres;
+        // SAFETY: at this point we have already checked that strres.string is
+        // NOT NULL.
+        unsafe {
+            addrres = CStr::from_ptr(strres.string).to_str();
+        }
+
+        Ok(addrres.expect("invalid underlying c-binding"))
+    }
+
+    /// It serializes an access grant such that it can be used to create a
+    /// [`Self::new()`] instance of this type or parsed with other tools.
+    pub fn serialize(&self) -> Result<&str, Error> {
+        let strres;
+        // SAFETY: we trust that the underlying c-binding is safe, nonetheless
+        // we ensure strres is correct through the ensure method of the
+        // implemented Ensurer trait.
+        unsafe {
+            strres = *ulksys::uplink_access_serialize(self.inner.access).ensure();
+        }
+
+        if let Some(e) = Error::new_uplink(strres.error) {
+            return Err(e);
+        }
+
+        let serialized;
+        // SAFETY: at this point we have already checked that strres.string is
+        // NOT NULL.
+        unsafe {
+            serialized = CStr::from_ptr(strres.string).to_str();
+        }
+
+        Ok(serialized.expect("invalid underlying c-binding"))
+    }
+
+    /// It creates a new access grant with specific permissions.
+    ///
+    /// An access grant can only have their existing permissions restricted, and
+    /// the resulting access will only allow for the intersection of all
+    /// previous share calls in the access construction chain.
+    ///
+    /// Prefixes restrict the access grant (and internal encryption information)
+    /// to only contain enough information to allow access to just those
+    /// prefixes.
+    ///
+    /// To revoke an access grant see [`Project.revoke_access()`](struct.Project.html#method.revoke_access).
+    ///
+    pub fn share(
+        &self,
+        permission: &Permission,
+        prefixes: Vec<SharePrefix>,
+    ) -> Result<Access, Error> {
+        let mut ulk_prefixes: Vec<ulksys::UplinkSharePrefix> = Vec::with_capacity(prefixes.len());
+
+        for sp in prefixes {
+            ulk_prefixes.push(sp.to_uplink_c())
+        }
+
+        let accres;
+        // SAFETY: we trust that the underlying c-binding is safe, nonetheless
+        // we ensure accres is correct through the ensure method of the
+        // implemented Ensurer trait.
+        unsafe {
+            accres = *ulksys::uplink_access_share(
+                self.inner.access,
+                permission.to_uplink_c(),
+                ulk_prefixes.as_mut_ptr(),
+                ulk_prefixes.len() as i64,
+            )
+            .ensure()
+        }
+
+        if let Some(e) = Error::new_uplink(accres.error) {
+            return Err(e);
+        }
+
+        Ok(Access { inner: accres })
+    }
+}
+
+impl Drop for Access {
+    fn drop(&mut self) {
+        // SAFETY: we trust that the underlying c-binding is safe freeing the
+        // memory of a correct UplinkAccessResult value.
+        unsafe { ulksys::uplink_free_access_result(self.inner) }
+    }
+}
+
+/// Represents a prefix to be shared.
+#[derive(Debug)]
+pub struct SharePrefix<'a> {
+    bucket: &'a str,
+    prefix: &'a str,
+}
+
+impl<'a> SharePrefix<'a> {
+    /// Create a new prefix to be shared in the specified bucket.
+    /// It returns an error if bucket or prefix contains a null character
+    /// (0 byte).
+    pub fn new(bucket: &'a str, prefix: &'a str) -> Result<Self, Error> {
+        if bucket.contains('\0') {
+            return Err(Error::new_invalid_arguments(
+                "bucket",
+                "cannot contains null bytes (0 byte)",
+            ));
+        }
+
+        if prefix.contains('\0') {
+            return Err(Error::new_invalid_arguments(
+                "prefix",
+                "cannot contains null bytes (0 byte)",
+            ));
+        }
+
+        Ok(SharePrefix { bucket, prefix })
+    }
+
+    /// Returns the bucket where the prefix to be shared belongs.
+    pub fn bucket(&self) -> &str {
+        self.bucket
+    }
+
+    /// Returns the actual prefix to be shared.
+    pub fn prefix(&self) -> &str {
+        self.prefix
+    }
+
+    /// Returns an UplinkSharePrefix with the values of this SharedPrefix for
+    /// interoperating with the uplink c-bindings.
+    /// It panics if creating a CString from bucket or prefix returns an error
+    /// because, in that case, there is a bug in the implementation or an
+    /// internal misuage of this type.
+    fn to_uplink_c(&self) -> ulksys::UplinkSharePrefix {
+        let bucket = match CString::new(self.bucket) {
+            Ok(cs) => cs,
+            Err(e) => panic!(
+                "BUG: Never set a value to the `bucket` field without previously guarantee there won't be an error converting it to a CString value. Error details: {}", e),
+        };
+
+        let prefix = match CString::new(self.prefix) {
+            Ok(cs) => cs,
+            Err(e) => panic!("BUG: Never set a value to the `prefix` field without previously guarantee there won't be an error converting it to a CString value. Error details: {}",e),
+        };
+
+        ulksys::UplinkSharePrefix {
+            bucket: bucket.into_raw(),
+            prefix: prefix.into_raw(),
+        }
+    }
+}
+
+/// Defines what actions and an optional specific period of time are granted to
+/// a shared Access Grant.
+/// A shared Access Grant can never has more permission that its parent, hence
+/// even some allowed permission is set for the shared Access Grant but not to
+/// its parent, the shared Access Grant won't be allowed.
+/// shared Access Grant wont
+/// See [`Access.share()`](struct.Access.html#method.share).
+#[derive(Default)]
+pub struct Permission {
+    /// Gives permission to download the content of the objects and their
+    /// associated metadata, but it does not allow listing buckets.
+    pub allow_download: bool,
+    /// Gives permission to create buckets and upload new objects. It does not
+    /// allow overwriting existing objects unless allow_delete is granted too.
+    pub allow_upload: bool,
+    /// Gives permission to list buckets and getting the metadata of the
+    /// objects. It does not allow downloading the content of the objects.
+    pub allow_list: bool,
+    /// Gives permission to delete buckets and objects. Unless either allow
+    /// allow_download or allow_list is grated too, neither the metadata of the
+    /// objects nor error information will be returned for deleted objects.
+    pub allow_delete: bool,
+    /// Restricts when the resulting access grant is valid for. If it is set
+    /// then it must always be before not_after and the resulting access grant
+    /// will not work if the satellite believes the time is before the set it
+    /// one.
+    /// The time is measured with the number of seconds since the Unix Epoch
+    /// time.
+    not_before: Option<Duration>,
+    /// Restricts when the resulting access grant is valid for. If it is set
+    /// then it must always be after not_before and the resulting access grant
+    /// will not work if the satellite believes the time is after the set it
+    /// one.
+    /// The time is measured with the number of seconds since the Unix Epoch
+    /// time.
+    not_after: Option<Duration>,
+}
+
+impl Permission {
+    /// Creates a permission that doesn't allow any operation, which is the
+    /// default permission.
+    /// This constructor is useful for creating a permission for after setting
+    /// the specific allowed operations when none of the other constructors
+    /// creates a permission with a set of allowed operations that works for
+    /// your use case.
+    pub fn new() -> Permission {
+        Permission {
+            ..Default::default()
+        }
+    }
+
+    /// Creates a permission that allows all the operations (i.e. Downloading,
+    /// uploading, listing and deleting).
+    pub fn full() -> Permission {
+        Permission {
+            allow_download: true,
+            allow_upload: true,
+            allow_list: true,
+            allow_delete: true,
+            not_before: None,
+            not_after: None,
+        }
+    }
+
+    /// Creates a permission that allows for reading (i.e. Downloading) and
+    /// listing.
+    pub fn read_only() -> Permission {
+        Permission {
+            allow_download: true,
+            allow_upload: false,
+            allow_list: true,
+            allow_delete: false,
+            not_before: None,
+            not_after: None,
+        }
+    }
+
+    /// Creates a permission that allows for writing (i.e. Uploading) and
+    /// deleting.
+    pub fn write_only() -> Permission {
+        Permission {
+            allow_download: false,
+            allow_upload: true,
+            allow_list: false,
+            allow_delete: true,
+            not_before: None,
+            not_after: None,
+        }
+    }
+
+    /// Returns the duration from Unix Epoch time since this permission is
+    /// valid.
+    /// Return None when there is not before restriction.
+    pub fn not_before(&self) -> Option<Duration> {
+        self.not_before
+    }
+
+    /// Set a not before valid time for this permission or removing it when None
+    /// is passed.
+    /// An error is returned if since is more recent or equal to the current
+    /// not after valid time of the permission, when not after is set.
+    /// The time is measured with the number of seconds since the Unix Epoch
+    /// time.
+    pub fn set_not_before(&mut self, since: Option<Duration>) -> Result<(), Error> {
+        if let Some(since) = since {
+            if let Some(until) = self.not_after {
+                if since >= until {
+                    return Err(Error::new_invalid_arguments(
+                    "since",
+                    "cannot be more recent or equal to the not after valid time of the permission",
+                ));
+                }
+            }
+        }
+
+        self.not_before = since;
+        Ok(())
+    }
+
+    /// Returns the duration from Unix Epoch time until this permission is
+    /// valid.
+    /// Return None when there is not after restriction.
+    pub fn not_after(&self) -> Option<Duration> {
+        self.not_after
+    }
+
+    /// Set a not after valid time for this permission or removing it when None
+    /// is passed.
+    /// An error is returned if until is previous or equal to the current
+    /// not before valid time of the permission, when not before is set.
+    /// The time is measured with the number of seconds since the Unix Epoch
+    /// time.
+    pub fn set_not_after(&mut self, until: Option<Duration>) -> Result<(), Error> {
+        if let Some(until) = until {
+            if let Some(since) = self.not_before {
+                if until <= since {
+                    return Err(Error::new_invalid_arguments(
+                    "until",
+                    "cannot be previous or equal to the not before valid time of the permission",
+                ));
+                }
+            }
+        }
+
+        self.not_after = until;
+        Ok(())
+    }
+
+    /// Returns an UplinkPermission with the values of this Permission for
+    /// interoperating with the uplink c-bindings.
+    fn to_uplink_c(&self) -> ulksys::UplinkPermission {
+        ulksys::UplinkPermission {
+            allow_download: self.allow_download,
+            allow_upload: self.allow_upload,
+            allow_list: self.allow_list,
+            allow_delete: self.allow_delete,
+            not_before: self.not_before.map_or(0, |d| d.as_secs()) as i64,
+            not_after: self.not_after.map_or(0, |d| d.as_secs()) as i64,
+        }
+    }
+}
+
+impl Ensurer for ulksys::UplinkAccessResult {
+    fn ensure(&self) -> &Self {
+        assert!(!self.access.is_null() || !self.error.is_null(), "invalid underlying c-binding returned UplinkAccessResult, access and error fields are both NULL");
+        assert!(!self.access.is_null() && !self.error.is_null(), "invalid underlying c-binding returned UplinkAccessResult, access and error fields are both NOT NULL");
+        self
+    }
+}
+
+impl Ensurer for ulksys::UplinkStringResult {
+    fn ensure(&self) -> &Self {
+        assert!(!self.string.is_null() || !self.error.is_null(), "invalid underlying c-binding returned UplinkStringResult, string and error fields are both NULL");
+        assert!(!self.string.is_null() && !self.error.is_null(), "invalid underlying c-binding returned UplinkStringResult, string and error fields are both NOT NULL");
+        self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::error;
+
+    #[test]
+    fn test_share_prefix() {
+        {
+            // Pass a valid bucket and prefix.
+            let sp = SharePrefix::new("a-bucket", "a/b/c")
+                .expect("new shouldn't fail when passing a valid bucket and prefix");
+            assert_eq!(sp.bucket(), "a-bucket", "bucket");
+            assert_eq!(sp.prefix(), "a/b/c", "prefix");
+        }
+
+        {
+            // Pass an invalid bucket.
+            if let Error::InvalidArguments(error::Args { names, msg }) =
+                SharePrefix::new("a\0bucket\0", "a/b/c")
+                    .expect_err("new passing a bucket with NULL bytes")
+            {
+                assert_eq!(names, "bucket", "invalid error argument name");
+                assert_eq!(
+                    msg, "cannot contains null bytes (0 byte)",
+                    "invalid error argument message"
+                );
+            } else {
+                panic!("expected an invalid argument error");
+            }
+        }
+
+        {
+            // Pass an invalid prefix.
+            if let Error::InvalidArguments(error::Args { names, msg }) =
+                SharePrefix::new("a-bucket", "a/b\0/c")
+                    .expect_err("new passing a prefix with NULL bytes")
+            {
+                assert_eq!(names, "prefix", "invalid error argument name");
+                assert_eq!(
+                    msg, "cannot contains null bytes (0 byte)",
+                    "invalid error argument message"
+                );
+            } else {
+                panic!("expected an invalid argument error");
+            }
+        }
+
+        {
+            // Pass an invalid bucket and prefix.
+            if let Error::InvalidArguments(error::Args { names, msg }) =
+                SharePrefix::new("a\0bucket", "a/b\0/c")
+                    .expect_err("new passing a bucket and prefix with NULL bytes")
+            {
+                assert_eq!(names, "bucket", "invalid error argument name");
+                assert_eq!(
+                    msg, "cannot contains null bytes (0 byte)",
+                    "invalid error argument message"
+                );
+            } else {
+                panic!("expected an invalid argument error");
+            }
+        }
+    }
+
+    #[test]
+    fn test_permission_default() {
+        let perm = Permission::new();
+
+        assert!(!perm.allow_download, "allow download");
+        assert!(!perm.allow_upload, "allow upload");
+        assert!(!perm.allow_list, "allow list");
+        assert!(!perm.allow_delete, "allow delete");
+        assert_eq!(perm.not_before(), None, "not before");
+        assert_eq!(perm.not_after(), None, "not after");
+    }
+
+    #[test]
+    fn test_permission_full() {
+        let perm = Permission::full();
+
+        assert!(perm.allow_download, "allow download");
+        assert!(perm.allow_upload, "allow upload");
+        assert!(perm.allow_list, "allow list");
+        assert!(perm.allow_delete, "allow delete");
+        assert_eq!(perm.not_before(), None, "not before");
+        assert_eq!(perm.not_after(), None, "not after");
+    }
+
+    #[test]
+    fn test_permission_read_only() {
+        let perm = Permission::read_only();
+
+        assert!(perm.allow_download, "allow download");
+        assert!(!perm.allow_upload, "allow upload");
+        assert!(perm.allow_list, "allow list");
+        assert!(!perm.allow_delete, "allow delete");
+        assert_eq!(perm.not_before(), None, "not before");
+        assert_eq!(perm.not_after(), None, "not after");
+    }
+
+    #[test]
+    fn test_permission_write_only() {
+        let perm = Permission::write_only();
+
+        assert!(!perm.allow_download, "allow download");
+        assert!(perm.allow_upload, "allow upload");
+        assert!(!perm.allow_list, "allow list");
+        assert!(perm.allow_delete, "allow delete");
+        assert_eq!(perm.not_before(), None, "not before");
+        assert_eq!(perm.not_after(), None, "not after");
+    }
+
+    #[test]
+    fn test_permission_time_boundaries() {
+        let mut perm = Permission::full();
+
+        assert_eq!(perm.not_before(), None, "not before");
+        assert_eq!(perm.not_after(), None, "not after");
+
+        // set not before and after without violating their constraints.
+        {
+            perm.set_not_before(Some(Duration::new(5, 50)))
+                .expect("set not before");
+            assert_eq!(
+                perm.not_before(),
+                Some(Duration::new(5, 50)),
+                "set not before"
+            );
+
+            perm.set_not_after(Some(Duration::new(5, 51)))
+                .expect("set not after");
+            assert_eq!(
+                perm.not_after(),
+                Some(Duration::new(5, 51)),
+                "set not after"
+            );
+        }
+
+        // set not before violating its constraints.
+        {
+            if let Error::InvalidArguments(error::Args { names, msg }) = perm
+                .set_not_before(Some(Duration::new(5, 52)))
+                .expect_err("set not before")
+            {
+                assert_eq!(names, "since", "invalid error argument name");
+                assert_eq!(
+                    msg,
+                    "cannot be more recent or equal to the not after valid time of the permission",
+                    "invalid error argument message"
+                );
+            } else {
+                panic!("expected an invalid argument error");
+            }
+        }
+
+        // set not after violating its constraints.
+        {
+            if let Error::InvalidArguments(error::Args { names, msg }) = perm
+                .set_not_after(Some(Duration::new(5, 50)))
+                .expect_err("set not after")
+            {
+                assert_eq!(names, "until", "invalid error argument name");
+                assert_eq!(
+                    msg,
+                    "cannot be previous or equal to the not before valid time of the permission",
+                    "invalid error argument message"
+                );
+            } else {
+                panic!("expected an invalid argument error");
+            }
+        }
+
+        // removing not before and after
+        {
+            perm.set_not_before(None).expect("set not before");
+            assert_eq!(perm.not_before(), None, "removing not before");
+
+            perm.set_not_after(None).expect("set not after");
+            assert_eq!(perm.not_after(), None, "removing not after");
+        }
+    }
+}

--- a/src/encryption_key.rs
+++ b/src/encryption_key.rs
@@ -1,0 +1,14 @@
+//! Storj DCS Encryption key
+
+use uplink_sys as ulksys;
+
+/// TODO: implement & document it
+pub struct EncryptionKey {
+    inner: ulksys::UplinkEncryptionKeyResult,
+}
+
+impl EncryptionKey {
+    pub(crate) fn into_raw_mut(&self) -> *mut ulksys::UplinkEncryptionKey {
+        self.inner.encryption_key
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,193 @@
+//! Errors returned by this crate.
+
+use std::error as stderr;
+use std::fmt;
+
+use uplink_sys as ulksys;
+
+/// The error type that this create use to wrap errors.
+#[derive(Debug)]
+pub enum Error {
+    /// Identifies invalid arguments passed to a function or method.
+    InvalidArguments(Args),
+    /// Identifies a native error returned by the underlying Uplink C bindings
+    /// library.
+    Uplink(UplinkErrorDetails),
+}
+
+impl Error {
+    /// Convenient constructor for creating an InvalidArguments Error.
+    /// See [`Args`] documentation to know about the convention for the value of
+    /// the `names` parameter because this constructor panics if they are
+    /// violated.
+    pub fn new_invalid_arguments(names: &str, msg: &str) -> Self {
+        Self::InvalidArguments(Args::new(names, msg))
+    }
+
+    /// Convenient constructor for creating an Uplink Error.
+    /// It returns None if ulkerr is null.
+    pub fn new_uplink(ulkerr: *mut ulksys::UplinkError) -> Option<Self> {
+        if let Some(d) = UplinkErrorDetails::from_raw(ulkerr) {
+            Some(Self::Uplink(d))
+        } else {
+            None
+        }
+    }
+}
+
+impl stderr::Error for Error {
+    fn source(&self) -> Option<&(dyn stderr::Error + 'static)> {
+        match self {
+            Error::InvalidArguments { .. } => None,
+            Error::Uplink { .. } => None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Error::InvalidArguments(args) => {
+                write!(f, "{}", args)
+            }
+            Error::Uplink(details) => {
+                write!(f, "{}", details)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Represents invalid arguments regarding the business domain.
+///
+/// # Example
+///
+/// ```
+/// use storj_uplink_lib::Error;
+///
+/// fn positive_non_zero_div_and_mul(a: i64, b: i64, div: i64) -> Result<i64, Error> {
+///     if div == 0 {
+///         return Err(Error::new_invalid_arguments("div", "div cannot be 0"));
+///     }
+///
+///     if (a == 0 && b != 0) || (a != 0 && b == 0) {
+///         return Err(Error::new_invalid_arguments(
+///             "(a,b)", "a and b can only be 0 if both are 0",
+///         ));
+///     }
+///
+///     if (a >= 0 && b >= 0 && div > 0) || (a <= 0 && b <= 0 && div < 0 ) {
+///         return Ok((a/div) * (b/div));
+///     }
+///
+///     Err(Error::new_invalid_arguments(
+///         "<all>", "all the arguments must be positive or negative, they cannot be mixed",
+///     ))
+/// }
+/// ```
+pub struct Args {
+    /// `names` is one or several parameters names; it has several conventions
+    /// for expressing the involved parameters.
+    ///
+    /// * When a specific parameter is invalid its value is the exact parameter
+    ///   name.
+    /// * When the parameter is a list (vector, array, etc.), the invalid items
+    ///   can be __optionally__ indicated using square brackets (e.g. `l[3,5,7]`).
+    /// * when the parameter is struct, the invalid fields or method return
+    ///   return values can be __optionally__ indicated using curly brackets
+    ///   (e.g invalid field: `person{name}`, invalid method return value:
+    ///   `person{full_name()}`, invalid fields/methods:
+    ///   `employee{name, position()}`).
+    /// * When several parameters are invalid, its values is the parameters
+    ///   names wrapped in round brackets (e.g. `(p1,p3)`); it also accepts any
+    ///   above combination of parameters types
+    ///   (e.g. `(p1, l[2,10], person{name})`).
+    /// * When all the function parameters are invalid, `<all>` is used.
+    ///
+    /// For enforcing the conventions across your code base use the
+    /// [`Error::new_invalid_arguments`] constructor function.
+    pub names: String,
+    /// `msg` is a human friendly message that explains why the argument(s) are
+    /// invalid.
+    pub msg: String,
+}
+
+impl Args {
+    // TODO: this constructor must enforce the names convention commented in the
+    // documentation of this type and panic if they are violated because that
+    // means that there is a bug in the code that uses it.
+    fn new(names: &str, msg: &str) -> Self {
+        Args {
+            names: String::from(names),
+            msg: String::from(msg),
+        }
+    }
+}
+
+impl fmt::Display for Args {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "{} argurments have invalid values. {}",
+            self.names, self.msg
+        )
+    }
+}
+
+#[derive(Debug)]
+/// Wraps a native error returned by the underlying Uplink C bindings library
+/// providing the access to its details.
+pub struct UplinkErrorDetails {
+    /// the error code returned by the underlying Uplink C bindings library.
+    pub code: i32,
+    /// the error message returned by the underlying Uplink C bindings library
+    /// converted to a String.
+    pub details: String,
+}
+
+impl UplinkErrorDetails {
+    fn from_raw(ulkerr: *mut ulksys::UplinkError) -> Option<Self> {
+        if ulkerr.is_null() {
+            return None;
+        }
+
+        // This is safe because the we have checked just above that the pointer
+        // isn't null
+        unsafe {
+            Some(Self {
+                code: (*ulkerr).code,
+                details: (*ulkerr).message.as_ref().unwrap().to_string(),
+            })
+        }
+    }
+
+    fn message(&self) -> &str {
+        match self.code as u32 {
+            ulksys::UPLINK_ERROR_INTERNAL => "internal",
+            ulksys::UPLINK_ERROR_CANCELED => "canceled",
+            ulksys::UPLINK_ERROR_INVALID_HANDLE => "invalid handle",
+            ulksys::UPLINK_ERROR_TOO_MANY_REQUESTS => "too many requests",
+            ulksys::UPLINK_ERROR_BANDWIDTH_LIMIT_EXCEEDED => "bandwidth limit exceeded",
+            ulksys::UPLINK_ERROR_BUCKET_NAME_INVALID => "invalid bucket name",
+            ulksys::UPLINK_ERROR_BUCKET_ALREADY_EXISTS => "bucket already exists",
+            ulksys::UPLINK_ERROR_BUCKET_NOT_EMPTY => "bucket not empty",
+            ulksys::UPLINK_ERROR_BUCKET_NOT_FOUND => "bucket not found",
+            ulksys::UPLINK_ERROR_OBJECT_KEY_INVALID => "invalid object key",
+            ulksys::UPLINK_ERROR_OBJECT_NOT_FOUND => "object not found",
+            ulksys::UPLINK_ERROR_UPLOAD_DONE => "upload done",
+            _ => "unknown",
+        }
+    }
+}
+
+impl fmt::Display for UplinkErrorDetails {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            r#"Uplink error: code: {}, message: "{}", details: "{}""#,
+            self.code,
+            self.message(),
+            self.details,
+        )
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,52 @@
+//! Helper functions which are used across the modules of this crate
+
+use super::Error;
+
+use std::ffi::CString;
+
+/// creates a CString from a function &str function argument and if there is an
+/// error it returnns an Error::InvalidArguments with the passed argument's
+/// name.
+pub fn cstring_from_str_fn_arg(arg_name: &str, arg_val: &str) -> Result<CString, Error> {
+    match CString::new(arg_val) {
+        Ok(cs) => Ok(cs),
+        Err(e) => Err(Error::new_invalid_arguments(
+            arg_name,
+            &format!(
+                "cannot contains null bytes (0 byte). Null byte found at {}",
+                e.nul_position()
+            ),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_cstring_from_str_fn_arg() {
+        let val = cstring_from_str_fn_arg("some", "this is fine")
+            .expect("returned error on a valid CString");
+        assert_eq!(
+            val,
+            CString::new("this is fine").unwrap(),
+            "returned a CString with an invalid value"
+        );
+
+        let err = cstring_from_str_fn_arg("some", "this is invalid\0 ")
+            .expect_err("returned Ok on an invalid CString");
+        if let Error::InvalidArguments(args) = err {
+            assert_eq!(
+                args.names, "some",
+                "invalid Error::InvalidArguments name field value"
+            );
+            assert_eq!(
+                args.msg, "cannot contains null bytes (0 byte). Null byte found at 15",
+                "invalid Error::InvalidArguments msg field value"
+            )
+        } else {
+            panic!("expected an Error::InvalidArguments");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,28 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
+//! Storj DCS Uplink idiomatic and safe Rust bindings.
+
+#![deny(missing_docs)]
+
+pub(crate) mod access;
+pub(crate) mod encryption_key;
+pub mod error;
+pub(crate) mod helpers;
+pub(crate) mod project;
+
+pub use access::Access;
+pub use access::Permission;
+pub use access::SharePrefix;
+pub use encryption_key::EncryptionKey;
+pub use error::Error;
+pub use project::Project;
+
+/// An interface for ensuring that an instance of type returned by the
+/// underlying c-binding is correct in terms that it doesn't violate its own
+/// rules.
+/// For example a UplinkAccessResult struct has 2 fields which are 2 pointers,
+/// one is the access and the other is an error, always one and only one can be
+/// NULL.
+trait Ensurer {
+    /// Checks that the instance is correct according its own rules and it
+    /// returns itself, otherwise it panics.
+    fn ensure(&self) -> &Self;
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,0 +1,11 @@
+//! Storj DCS Project.
+
+/// TODO: document it.
+pub struct Project {}
+
+impl Project {
+    /// TODO: document this method.
+    pub fn revoke_access(&self) {
+        todo!("implement it")
+    }
+}


### PR DESCRIPTION
Implement the Uplink 'access', its bound types, and create related types
which are needed for creating it.

This commit also implements some base types to be used by the several
types that the crate is going to expose:

* A specific error type which will be returned as an error by any
  implemented type for returning homogenized errors and ease the
  consumers to handle them appropriately.
* A helper function to convert strings to C strings.

And also add to the README the list of Uplink types to implement to 
indicate the implementation progress of the first usable version of this
crate.