### PR TITLE
feat: Implement Uplink Bucket & Iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Entities:
 
 - [X] [Access](https://pkg.go.dev/storj.io/uplink#Access)
 - [X] [Bucket](https://pkg.go.dev/storj.io/uplink#Bucket)
-- [ ] [Bucket Iterator](https://pkg.go.dev/storj.io/uplink#BucketIterator)
+- [X] [Bucket Iterator](https://pkg.go.dev/storj.io/uplink#BucketIterator)
 - [ ] [Config](https://pkg.go.dev/storj.io/uplink#Config)
 - [ ] [Custom Metadata](https://pkg.go.dev/storj.io/uplink#CustomMetadata)
 - [ ] [Download](https://pkg.go.dev/storj.io/uplink#Download)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ keyword for using it) Rust crate library based on the Bindgen former.
 Entities:
 
 - [X] [Access](https://pkg.go.dev/storj.io/uplink#Access)
-- [ ] [Bucket](https://pkg.go.dev/storj.io/uplink#Bucket)
+- [X] [Bucket](https://pkg.go.dev/storj.io/uplink#Bucket)
 - [ ] [Bucket Iterator](https://pkg.go.dev/storj.io/uplink#BucketIterator)
 - [ ] [Config](https://pkg.go.dev/storj.io/uplink#Config)
 - [ ] [Custom Metadata](https://pkg.go.dev/storj.io/uplink#CustomMetadata)

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,0 +1,77 @@
+//! Storj DSC Bucket and related types.
+
+use crate::{Ensurer, Error};
+
+use std::ffi::CStr;
+use std::time::Duration;
+
+use uplink_sys as ulksys;
+
+/// Contains information about a specific bucket.
+pub struct Bucket<'a> {
+    /// The bucket type of the underlying c-bindings Rust crate that an instance
+    /// of this struct represents and guard its life time until this instance
+    /// drops.
+    inner: *mut ulksys::UplinkBucket,
+
+    /// Name of the bucket.
+    pub name: &'a str,
+    /// Unix Epoch time when the bucket was created.
+    pub created_at: Duration,
+}
+
+impl<'a> Bucket<'a> {
+    /// Creates a Bucket instance from the type exposed by the uplink
+    /// c-bindings.
+    pub(crate) fn from_uplink_c(uc_bucket: *mut ulksys::UplinkBucket) -> Result<Self, Error> {
+        if uc_bucket.is_null() {
+            return Err(Error::new_invalid_arguments("uc_bucket", "cannot be null"));
+        }
+
+        let name: &str;
+        let created_at: Duration;
+        // SAFETY: uc_bucket cannot be null because it's checked at the
+        // beginning of the function and we ensure uc_bucket doesn't have fields
+        // with NULL pointes through the ensure method of the implemented
+        // Ensurer trait.
+        unsafe {
+            (*uc_bucket).ensure();
+
+            match CStr::from_ptr((*uc_bucket).name).to_str() {
+                Ok(n) => name = n,
+                Err(err) => {
+                    return Err(Error::new_internal_with_inner(
+                        "invalid bucket name because it contains invalid UTF-8 characters",
+                        err.into(),
+                    ));
+                }
+            };
+
+            created_at = Duration::new((*uc_bucket).created as u64, 0);
+        }
+
+        Ok(Bucket {
+            inner: uc_bucket,
+            name,
+            created_at,
+        })
+    }
+}
+
+impl<'a> Drop for Bucket<'a> {
+    fn drop(&mut self) {
+        // SAFETY: we trust that the underlying c-binding is safe freeing the
+        // memory of a correct UplinkBucket value.
+        unsafe { ulksys::uplink_free_bucket(self.inner) }
+    }
+}
+
+impl Ensurer for ulksys::UplinkBucket {
+    fn ensure(&self) -> &Self {
+        assert!(
+            !self.name.is_null(),
+            "invalid underlying c-binding returned invalid UplinkBucket; name field is NULL"
+        );
+        self
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,9 +5,14 @@ use std::fmt;
 
 use uplink_sys as ulksys;
 
+pub(crate) type BoxError = Box<dyn stderr::Error + Send + Sync>;
+
 /// The error type that this create use to wrap errors.
 #[derive(Debug)]
 pub enum Error {
+    /// Identifies errors produced by the internal implementation (e.g.
+    /// exchanging values with the C, etc. )that aren't expected to happen.
+    Internal(InternalDetails),
     /// Identifies invalid arguments passed to a function or method.
     InvalidArguments(Args),
     /// Identifies a native error returned by the underlying Uplink C bindings
@@ -16,6 +21,20 @@ pub enum Error {
 }
 
 impl Error {
+    pub(crate) fn new_internal(ctx_msg: &str) -> Self {
+        Error::Internal(InternalDetails {
+            ctx_msg: String::from(ctx_msg),
+            inner: None,
+        })
+    }
+
+    pub(crate) fn new_internal_with_inner(ctx_msg: &str, berr: BoxError) -> Self {
+        Error::Internal(InternalDetails {
+            ctx_msg: String::from(ctx_msg),
+            inner: Some(berr),
+        })
+    }
+
     /// Convenient constructor for creating an InvalidArguments Error.
     /// See [`Args`] documentation to know about the convention for the value of
     /// the `names` parameter because this constructor panics if they are
@@ -36,6 +55,7 @@ impl stderr::Error for Error {
         match self {
             Error::InvalidArguments { .. } => None,
             Error::Uplink { .. } => None,
+            Error::Internal(InternalDetails { inner, .. }) => inner.as_ref().map(|be| &**be as _),
         }
     }
 }
@@ -47,6 +67,9 @@ impl fmt::Display for Error {
                 write!(f, "{}", args)
             }
             Error::Uplink(details) => {
+                write!(f, "{}", details)
+            }
+            Error::Internal(details) => {
                 write!(f, "{}", details)
             }
         }
@@ -188,5 +211,30 @@ impl fmt::Display for UplinkErrorDetails {
             self.message(),
             self.details,
         )
+    }
+}
+
+/// Represents an error that happen because of the violation of an internal
+/// assumption.
+/// An assumption can be violated by the use of a function that returns an error
+/// when it should never return it or because it's validated explicitly by the
+/// implementation.
+/// An assumption examples is: a bucket's name returned by the Storj Satellite
+/// must always contain UTF-8 valid characters.
+#[derive(Debug)]
+pub struct InternalDetails {
+    /// A human friendly message to provide context of the error to receiver of
+    /// the error.
+    pub ctx_msg: String,
+    /// The inner error that caused this internal error; it's None when some
+    /// internal state/values are expected but those are rare situations because
+    /// the most of the times this internal errors should be originated by an
+    /// inner error.
+    inner: Option<BoxError>,
+}
+
+impl fmt::Display for InternalDetails {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.ctx_msg)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod helpers;
 pub(crate) mod project;
 
 pub mod access;
+pub mod bucket;
 pub use encryption_key::EncryptionKey;
 pub use error::Error;
 pub use project::Project;


### PR DESCRIPTION
Implement the struct types for Bucket and Bucket Iterator.

* Implement the Uplink 'bucket' and add a new variant to the Error type
  for representing internal errors because it's something that could
  happen when creating a 'bucket' from the Uplink c-bindings 'bucket' type
  and it's likely that will be other cases where an internal can happen.
  
  Also, updates the README, marking the task for implementing 'bucket' as
  done.
* Implement the Uplink 'bucket iterator' and updates the README to mark it
  done.